### PR TITLE
Refactor service calls to redux thunks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,5 @@
-import { useState, useEffect } from "react";
-import axios from "axios";
+import { useEffect } from "react";
 import "./App.css";
-import { API_BASE } from "./constants/constants";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Login from "./components/login/Login";
 import Dashboard from "./components/dashboard/Dashboard";
@@ -10,7 +8,7 @@ import Layout from "./components/layout/Layout";
 import { CssBaseline } from "@mui/material";
 import { getCarrierDetails } from "./components/utils/util";
 import { useDispatch } from "react-redux";
-import { setDashboardData } from "./store/dashboard/dashboardActions";
+import { fetchDashboard } from "./store/dashboard/dashboardThunks";
 import TowerRegistrationForm from "./components/registration/TowerRegistrationForm";
 import DeviceDiscovery from "./components/devicediscovery/DeviceDiscovery";
 import PolicySetupForm from "./components/policysetup/PolicySetupForm";
@@ -20,20 +18,12 @@ const App = () => {
   const user = useSelector((state: any) => state.user);
   const carrier = getCarrierDetails(user);
   const dispatch = useDispatch();
-  const [towerList, setTowerList] = useState([]);
-  const [simulate, setSimulate] = useState(null) as any;
-  const [policy, setPolicy] = useState(false);
+  const towerList = useSelector((state: any) => state.towers);
+  const simulate = useSelector((state: any) => state.device.simulated);
+  const policy = useSelector((state: any) => state.policy.applied);
 
-  const fetchApi = async (carrier: string) => {
-    const response = await axios.get(`${API_BASE}/dashboard`, {
-      params: {
-        carrier,
-      },
-      headers: {
-        "Cache-Control": "no-cache",
-      },
-    });
-    dispatch(setDashboardData(response));
+  const fetchApi = (carrier: string) => {
+    dispatch(fetchDashboard(carrier));
   };
 
   useEffect(() => {
@@ -47,25 +37,9 @@ const App = () => {
         <Routes>
           <Route path="/" element={<Login />} />
           <Route path="/dashboard" element={<Dashboard />} />
-          <Route
-            path="/tower-registration-form"
-            element={
-              <TowerRegistrationForm
-                setTowerList={setTowerList}
-                towerList={towerList}
-              />
-            }
-          />
-          <Route
-            path="/device-discovery-input"
-            element={
-              <DeviceDiscovery simulate={simulate} setSimulate={setSimulate} />
-            }
-          />
-          <Route
-            path="/policy-setup"
-            element={<PolicySetupForm setPolicy={setPolicy} />}
-          />
+          <Route path="/tower-registration-form" element={<TowerRegistrationForm />} />
+          <Route path="/device-discovery-input" element={<DeviceDiscovery />} />
+          <Route path="/policy-setup" element={<PolicySetupForm />} />
           <Route path="/user-action-log" element={<UserActionLog />} />
         </Routes>
       </Layout>

--- a/frontend/src/components/devicediscovery/DeviceDiscovery.tsx
+++ b/frontend/src/components/devicediscovery/DeviceDiscovery.tsx
@@ -7,54 +7,40 @@ import {
   Divider,
   Paper,
 } from "@mui/material";
-import axios from "axios";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { fetchDevices, simulateDevice } from "../../store/device/deviceThunks";
 import { generateRandomDevice } from "../utils/util";
 
-const API_BASE = "http://localhost:8000";
-
-const DeviceDiscovery: React.FC = ({ simulate, setSimulate }: any) => {
+const DeviceDiscovery: React.FC = () => {
   const [towerId, setTowerId] = useState("");
   const [location, setLocation] = useState("");
   const [coverageRadius, setCoverageRadius] = useState("");
   const [macAddress, setMacAddress] = useState("");
-  const [discoveredDevices, setDiscoveredDevices] = useState<any[]>([]);
   const [searchResult, setSearchResult] = useState<any | null>(null);
+  const dispatch = useDispatch();
   const user = useSelector((state: any) => state.user);
+  const discoveredDevices = useSelector((state: any) => state.device.discovered);
+  const simulate = useSelector((state: any) => state.device.simulated);
 
   const handleReset = () => {
     setTowerId("");
     setLocation("");
     setCoverageRadius("");
     setMacAddress("");
-    setDiscoveredDevices([]);
     setSearchResult(null);
+    dispatch(fetchDevices());
   };
 
   useEffect(() => {
-    fetchDeviceInfo();
-  }, [simulate]);
+    dispatch(fetchDevices());
+  }, [dispatch, simulate]);
 
   const handleSimulateDiscovery = async () => {
-    const newDevice = { ...generateRandomDevice(), user }; // generate fresh device
-    try {
-      await axios.post(`${API_BASE}/api/simulate-device`, newDevice); // use new device
-      setSimulate(newDevice); // reflect it in modal or UI
-      alert(`Device registered: ${newDevice.ip} / ${newDevice.mac}`);
-    } catch (err) {
-      console.error(err);
-      alert("Simulation failed");
-    }
+    const newDevice = { ...generateRandomDevice(), user };
+    dispatch(simulateDevice(newDevice));
+    alert(`Device registered: ${newDevice.ip} / ${newDevice.mac}`);
   };
 
-  const fetchDeviceInfo = async () => {
-    try {
-      const res = await axios.get(`${API_BASE}/api/device-discovery`);
-      setDiscoveredDevices(res.data);
-    } catch (err) {
-      console.error("Discovery failed", err);
-    }
-  };
 
   const handleSearch = () => {
     const match = discoveredDevices.find(

--- a/frontend/src/components/policysetup/PolicySetupForm.tsx
+++ b/frontend/src/components/policysetup/PolicySetupForm.tsx
@@ -10,8 +10,9 @@ import {
   Switch,
   Grid,
 } from "@mui/material";
-import { useSelector } from "react-redux";
-import axios from "axios";
+import { useSelector, useDispatch } from "react-redux";
+import { savePolicy } from "../../store/policy/policyThunks";
+import { setPolicyApplied } from "../../store/policy/policyActions";
 
 const POLICY_TYPES = [
   "Administrative",
@@ -29,7 +30,7 @@ const POLICY_TOGGLES = [
   "Block Jailbreak/Root Detection",
 ];
 
-const PolicySetupForm: React.FC = ({ setPolicy }: any) => {
+const PolicySetupForm: React.FC = () => {
   const [policyName, setPolicyName] = useState("");
   const [policyType, setPolicyType] = useState<string>("Device Management");
   const [toggles, setToggles] = useState<Record<string, boolean>>({
@@ -41,9 +42,10 @@ const PolicySetupForm: React.FC = ({ setPolicy }: any) => {
   });
   const user = useSelector((state: any) => state.user);
 
+  const dispatch = useDispatch();
   useEffect(() => {
-    setPolicy(false);
-  }, []);
+    dispatch(setPolicyApplied(false));
+  }, [dispatch]);
 
   const handleToggleChange = (label: string) => {
     setToggles((prev) => ({
@@ -60,12 +62,13 @@ const PolicySetupForm: React.FC = ({ setPolicy }: any) => {
     };
 
     try {
-      await axios.post("http://localhost:8000/api/policy", {
-        ...payload,
-        user: user.username || "admin",
-        carrier: user.carrier,
-      });
-      setPolicy(true);
+      await dispatch(
+        savePolicy({
+          ...payload,
+          user: user.username || "admin",
+          carrier: user.carrier,
+        })
+      );
       alert("Policy successfully saved and applied");
     } catch (err) {
       console.error("Failed to save policy", err);

--- a/frontend/src/components/registration/TowerRegistrationForm.tsx
+++ b/frontend/src/components/registration/TowerRegistrationForm.tsx
@@ -16,14 +16,14 @@ import {
   Grid,
   Chip,
 } from "@mui/material";
-import { useSelector } from "react-redux";
-import axios from "axios";
+import { useSelector, useDispatch } from "react-redux";
+import { fetchTowers, registerTower } from "../../store/towers/towerThunks";
 
 const CARRIER_OPTIONS = ["AT&T", "Verizon", "T-Mobile"];
 const OS_OPTIONS = ["iOS", "Android", "Windows"];
 const TOWER_TYPES = ["Monopole", "Lattice", "Guyed"];
 
-const TowerRegistrationForm: React.FC = ({ towerList, setTowerList }: any) => {
+const TowerRegistrationForm: React.FC = () => {
   const [id, setTowerId] = useState("");
 
   const [location, setLocation] = useState("");
@@ -38,19 +38,12 @@ const TowerRegistrationForm: React.FC = ({ towerList, setTowerList }: any) => {
     "Windows",
   ]);
   const user = useSelector((state: any) => state.user);
+  const towerList = useSelector((state: any) => state.towers);
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    const fetchTowers = async () => {
-      try {
-        const response = await axios.get("http://localhost:8000/api/towers");
-        const ids = response.data.map((t: any) => t.towerId);
-        setTowerList(ids);
-      } catch (error) {
-        console.error("Failed to fetch towers", error);
-      }
-    };
-    fetchTowers();
-  }, []);
+    dispatch(fetchTowers());
+  }, [dispatch]);
 
   const handleCarrierToggle = (carrier: string) => {
     setCarriers((prev) =>
@@ -85,21 +78,11 @@ const TowerRegistrationForm: React.FC = ({ towerList, setTowerList }: any) => {
       coverageRadius,
       carriers,
       supportedOS,
+      user,
     };
-    const registerTower = async () => {
-      try {
-        await axios.post("http://localhost:8000/api/register-tower", {
-          ...formData,
-          user,
-        });
-        setSnackbarOpen(true);
-        setTowerList((prev) => prev.filter((t) => t.id !== id));
-        setTowerId("");
-      } catch (error) {
-        console.error("Failed to register tower", error);
-      }
-    };
-    registerTower();
+    dispatch(registerTower(formData));
+    setSnackbarOpen(true);
+    setTowerId("");
   };
 
   return (

--- a/frontend/src/components/useraction/UserActionLog.tsx
+++ b/frontend/src/components/useraction/UserActionLog.tsx
@@ -12,8 +12,9 @@ import {
   Paper,
   Grid,
 } from "@mui/material";
-import axios from "axios";
+import { useDispatch, useSelector } from "react-redux";
 import { getUser } from "../utils/util";
+import { fetchUserLogs } from "../../store/userlogs/logThunks";
 
 type LogEntry = {
   userId: string;
@@ -24,7 +25,8 @@ type LogEntry = {
 const UserActionLog: React.FC = () => {
   const [fromDate, setFromDate] = useState("2025-05-31");
   const [toDate, setToDate] = useState("2025-06-01");
-  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const dispatch = useDispatch();
+  const logs = useSelector((state: any) => state.logs);
   const [loading, setLoading] = useState(false);
 
   const handleRetrieveLogs = async () => {
@@ -33,15 +35,9 @@ const UserActionLog: React.FC = () => {
       const user = JSON.parse(localStorage.getItem("user") || "{}");
       const carrier = user.carrier || "AT&T"; // fallback
 
-      const response = await axios.get("http://localhost:8000/api/user-logs", {
-        params: {
-          carrier,
-          start: fromDate,
-          end: toDate,
-        },
-      });
-
-      setLogs(response.data);
+      await dispatch(
+        fetchUserLogs({ carrier, start: fromDate, end: toDate })
+      );
     } catch (error) {
       console.error("Failed to fetch logs", error);
       alert("Unable to retrieve user logs.");

--- a/frontend/src/store/dashboard/dashboardThunks.ts
+++ b/frontend/src/store/dashboard/dashboardThunks.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+import { API_BASE } from "../../constants/constants";
+import { setDashboardData } from "./dashboardActions";
+import { AppDispatch } from "../store";
+
+export const fetchDashboard = (carrier: string) => async (dispatch: AppDispatch) => {
+  const response = await axios.get(`${API_BASE}/dashboard`, {
+    params: { carrier },
+    headers: { "Cache-Control": "no-cache" },
+  });
+  dispatch(setDashboardData(response));
+};

--- a/frontend/src/store/device/deviceActions.ts
+++ b/frontend/src/store/device/deviceActions.ts
@@ -1,0 +1,4 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const setDiscoveredDevices = createAction<any[]>("device/setDiscoveredDevices");
+export const setSimulatedDevice = createAction<any>("device/setSimulatedDevice");

--- a/frontend/src/store/device/deviceReducer.ts
+++ b/frontend/src/store/device/deviceReducer.ts
@@ -1,0 +1,24 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { setDiscoveredDevices, setSimulatedDevice } from "./deviceActions";
+
+interface DeviceState {
+  discovered: any[];
+  simulated: any | null;
+}
+
+const initialState: DeviceState = {
+  discovered: [],
+  simulated: null,
+};
+
+const deviceReducer = createReducer(initialState, (builder) => {
+  builder
+    .addCase(setDiscoveredDevices, (state, action) => {
+      state.discovered = action.payload;
+    })
+    .addCase(setSimulatedDevice, (state, action) => {
+      state.simulated = action.payload;
+    });
+});
+
+export default deviceReducer;

--- a/frontend/src/store/device/deviceThunks.ts
+++ b/frontend/src/store/device/deviceThunks.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { API_BASE } from "../../constants/constants";
+import { setDiscoveredDevices, setSimulatedDevice } from "./deviceActions";
+import { AppDispatch } from "../store";
+
+export const fetchDevices = () => async (dispatch: AppDispatch) => {
+  const res = await axios.get(`${API_BASE}/device-discovery`);
+  dispatch(setDiscoveredDevices(res.data));
+};
+
+export const simulateDevice = (device: any) => async (dispatch: AppDispatch) => {
+  await axios.post(`${API_BASE}/simulate-device`, device);
+  dispatch(setSimulatedDevice(device));
+};

--- a/frontend/src/store/policy/policyActions.ts
+++ b/frontend/src/store/policy/policyActions.ts
@@ -1,0 +1,3 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const setPolicyApplied = createAction<boolean>("policy/setPolicyApplied");

--- a/frontend/src/store/policy/policyReducer.ts
+++ b/frontend/src/store/policy/policyReducer.ts
@@ -1,0 +1,10 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { setPolicyApplied } from "./policyActions";
+
+const policyReducer = createReducer({ applied: false }, (builder) => {
+  builder.addCase(setPolicyApplied, (state, action) => {
+    state.applied = action.payload;
+  });
+});
+
+export default policyReducer;

--- a/frontend/src/store/policy/policyThunks.ts
+++ b/frontend/src/store/policy/policyThunks.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+import { API_BASE } from "../../constants/constants";
+import { setPolicyApplied } from "./policyActions";
+import { AppDispatch } from "../store";
+
+export const savePolicy = (payload: any) => async (dispatch: AppDispatch) => {
+  await axios.post(`${API_BASE}/policy`, payload);
+  dispatch(setPolicyApplied(true));
+};

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -1,11 +1,19 @@
 import { configureStore } from "@reduxjs/toolkit";
 import userReducer from "./user/userReducer";
 import dashboardReducer from "./dashboard/dashboardReducer";
+import towerReducer from "./towers/towerReducer";
+import deviceReducer from "./device/deviceReducer";
+import policyReducer from "./policy/policyReducer";
+import logReducer from "./userlogs/logReducer";
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
     dashboard: dashboardReducer,
+    towers: towerReducer,
+    device: deviceReducer,
+    policy: policyReducer,
+    logs: logReducer,
   },
 });
 

--- a/frontend/src/store/towers/towerActions.ts
+++ b/frontend/src/store/towers/towerActions.ts
@@ -1,0 +1,4 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const setTowers = createAction<string[]>("towers/setTowers");
+export const removeTowerId = createAction<string>("towers/removeTowerId");

--- a/frontend/src/store/towers/towerReducer.ts
+++ b/frontend/src/store/towers/towerReducer.ts
@@ -1,0 +1,10 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { setTowers, removeTowerId } from "./towerActions";
+
+const towerReducer = createReducer<string[]>([], (builder) => {
+  builder
+    .addCase(setTowers, (_, action) => action.payload)
+    .addCase(removeTowerId, (state, action) => state.filter((id) => id !== action.payload));
+});
+
+export default towerReducer;

--- a/frontend/src/store/towers/towerThunks.ts
+++ b/frontend/src/store/towers/towerThunks.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import { API_BASE } from "../../constants/constants";
+import { setTowers, removeTowerId } from "./towerActions";
+import { AppDispatch } from "../store";
+
+export const fetchTowers = () => async (dispatch: AppDispatch) => {
+  const response = await axios.get(`${API_BASE}/towers`);
+  const ids = response.data.map((t: any) => t.towerId);
+  dispatch(setTowers(ids));
+};
+
+export const registerTower = (data: any) => async (dispatch: AppDispatch) => {
+  await axios.post(`${API_BASE}/register-tower`, data);
+  dispatch(removeTowerId(data.id));
+};

--- a/frontend/src/store/userlogs/logActions.ts
+++ b/frontend/src/store/userlogs/logActions.ts
@@ -1,0 +1,3 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const setUserLogs = createAction<any[]>("logs/setUserLogs");

--- a/frontend/src/store/userlogs/logReducer.ts
+++ b/frontend/src/store/userlogs/logReducer.ts
@@ -1,0 +1,8 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { setUserLogs } from "./logActions";
+
+const logReducer = createReducer<any[]>([], (builder) => {
+  builder.addCase(setUserLogs, (_, action) => action.payload);
+});
+
+export default logReducer;

--- a/frontend/src/store/userlogs/logThunks.ts
+++ b/frontend/src/store/userlogs/logThunks.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+import { API_BASE } from "../../constants/constants";
+import { setUserLogs } from "./logActions";
+import { AppDispatch } from "../store";
+
+export const fetchUserLogs = (params: { carrier: string; start: string; end: string }) =>
+  async (dispatch: AppDispatch) => {
+    const response = await axios.get(`${API_BASE}/user-logs`, { params });
+    dispatch(setUserLogs(response.data));
+  };


### PR DESCRIPTION
## Summary
- switch service requests to redux thunks
- store tower, device, policy and log data in the redux store
- trigger dashboard refresh whenever state changes

## Testing
- `npm --prefix frontend run build` *(fails: Cannot find module '@reduxjs/toolkit')*
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
