### PR TITLE
Refactor types across frontend

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,8 +1,10 @@
 import { useSelector } from "react-redux";
 import { Card, CardContent, Typography, Grid, Box } from "@mui/material";
+import { RootState } from "../../store/store";
+import { TowerStatus } from "../../types/carrierType";
 
 const Dashboard = () => {
-  const dashboard = useSelector((state: any) => state.dashboard);
+  const dashboard = useSelector((state: RootState) => state.dashboard);
 
   return (
     <Box sx={{ padding: 5 }}>
@@ -85,7 +87,7 @@ const Dashboard = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {dashboard.towerStatuses.map((t) => {
+                  {dashboard.towerStatuses.map((t: TowerStatus) => {
                     return (
                       <tr key={t.id}>
                         <td

--- a/frontend/src/components/devicediscovery/DeviceDiscovery.tsx
+++ b/frontend/src/components/devicediscovery/DeviceDiscovery.tsx
@@ -10,17 +10,21 @@ import {
 import { useSelector, useDispatch } from "react-redux";
 import { fetchDevices, simulateDevice } from "../../store/device/deviceThunks";
 import { generateRandomDevice } from "../utils/util";
+import { RootState, AppDispatch } from "../../store/store";
+import { Device } from "../../types/carrierType";
 
 const DeviceDiscovery: React.FC = () => {
   const [towerId, setTowerId] = useState("");
   const [location, setLocation] = useState("");
   const [coverageRadius, setCoverageRadius] = useState("");
   const [macAddress, setMacAddress] = useState("");
-  const [searchResult, setSearchResult] = useState<any | null>(null);
-  const dispatch = useDispatch();
-  const user = useSelector((state: any) => state.user);
-  const discoveredDevices = useSelector((state: any) => state.device.discovered);
-  const simulate = useSelector((state: any) => state.device.simulated);
+  const [searchResult, setSearchResult] = useState<Device | null>(null);
+  const dispatch = useDispatch<AppDispatch>();
+  const user = useSelector((state: RootState) => state.user);
+  const discoveredDevices = useSelector(
+    (state: RootState) => state.device.discovered
+  );
+  const simulate = useSelector((state: RootState) => state.device.simulated);
 
   const handleReset = () => {
     setTowerId("");
@@ -36,7 +40,7 @@ const DeviceDiscovery: React.FC = () => {
   }, [dispatch, simulate]);
 
   const handleSimulateDiscovery = async () => {
-    const newDevice = { ...generateRandomDevice(), user };
+    const newDevice: Device = { ...generateRandomDevice(), user };
     dispatch(simulateDevice(newDevice));
     alert(`Device registered: ${newDevice.ip} / ${newDevice.mac}`);
   };
@@ -44,7 +48,7 @@ const DeviceDiscovery: React.FC = () => {
 
   const handleSearch = () => {
     const match = discoveredDevices.find(
-      (d) => d.ip === towerId || d.mac === macAddress
+      (d: Device) => d.ip === towerId || d.mac === macAddress
     );
     setSearchResult(match || null);
   };

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -14,14 +14,15 @@ import {
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { getUserName } from "../utils/util";
+import { RootState } from "../../store/store";
 
 const drawerWidth = 240;
 
-const Layout: React.FC<{ children: React.ReactNode }> = ({ children }: any) => {
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
   const isLoginPage = location.pathname === "/";
   const navigate = useNavigate();
-  const { user } = useSelector((state: any) => state);
+  const { user } = useSelector((state: RootState) => state);
   const username = getUserName(user);
 
   const handleLogout = () => {

--- a/frontend/src/components/policysetup/PolicySetupForm.tsx
+++ b/frontend/src/components/policysetup/PolicySetupForm.tsx
@@ -13,6 +13,8 @@ import {
 import { useSelector, useDispatch } from "react-redux";
 import { savePolicy } from "../../store/policy/policyThunks";
 import { setPolicyApplied } from "../../store/policy/policyActions";
+import { RootState, AppDispatch } from "../../store/store";
+import { PolicyPayload } from "../../types/carrierType";
 
 const POLICY_TYPES = [
   "Administrative",
@@ -40,9 +42,9 @@ const PolicySetupForm: React.FC = () => {
     "Block Restricted Apps": false,
     "Block Jailbreak/Root Detection": false,
   });
-  const user = useSelector((state: any) => state.user);
+  const user = useSelector((state: RootState) => state.user);
 
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   useEffect(() => {
     dispatch(setPolicyApplied(false));
   }, [dispatch]);
@@ -55,7 +57,7 @@ const PolicySetupForm: React.FC = () => {
   };
 
   const handleSubmit = async () => {
-    const payload = {
+    const payload: Omit<PolicyPayload, "user" | "carrier"> = {
       policyName,
       policyType,
       apply: toggles,

--- a/frontend/src/components/registration/TowerRegistrationForm.tsx
+++ b/frontend/src/components/registration/TowerRegistrationForm.tsx
@@ -18,6 +18,8 @@ import {
 } from "@mui/material";
 import { useSelector, useDispatch } from "react-redux";
 import { fetchTowers, registerTower } from "../../store/towers/towerThunks";
+import { RootState, AppDispatch } from "../../store/store";
+import { TowerRegistrationData } from "../../types/carrierType";
 
 const CARRIER_OPTIONS = ["AT&T", "Verizon", "T-Mobile"];
 const OS_OPTIONS = ["iOS", "Android", "Windows"];
@@ -37,9 +39,9 @@ const TowerRegistrationForm: React.FC = () => {
     "Android",
     "Windows",
   ]);
-  const user = useSelector((state: any) => state.user);
-  const towerList = useSelector((state: any) => state.towers);
-  const dispatch = useDispatch();
+  const user = useSelector((state: RootState) => state.user);
+  const towerList = useSelector((state: RootState) => state.towers);
+  const dispatch = useDispatch<AppDispatch>();
 
   useEffect(() => {
     dispatch(fetchTowers());
@@ -70,7 +72,7 @@ const TowerRegistrationForm: React.FC = () => {
   };
 
   const handleSubmit = () => {
-    const formData = {
+    const formData: TowerRegistrationData = {
       id,
       location,
       towerType,
@@ -95,17 +97,22 @@ const TowerRegistrationForm: React.FC = () => {
         <Autocomplete
           options={towerList}
           value={id}
-          onChange={(event: any, newValue: string | null) => {
+          onChange={(
+            event: React.SyntheticEvent,
+            newValue: string | null
+          ) => {
             setTowerId(newValue || "");
           }}
-          renderInput={(params: any) => (
+          renderInput={(params) => (
             <TextField
               {...params}
               fullWidth
               label="Tower ID"
               variant="outlined"
               value={id}
-              onClick={(e) => setTowerId(e.target.value)}
+              onClick={(e) =>
+                setTowerId((e.target as HTMLInputElement).value)
+              }
             />
           )}
         />

--- a/frontend/src/components/useraction/UserActionLog.tsx
+++ b/frontend/src/components/useraction/UserActionLog.tsx
@@ -15,18 +15,16 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import { getUser } from "../utils/util";
 import { fetchUserLogs } from "../../store/userlogs/logThunks";
+import { RootState, AppDispatch } from "../../store/store";
+import { LogEntry } from "../../types/carrierType";
 
-type LogEntry = {
-  userId: string;
-  action: string;
-  timestamp: string;
-};
+
 
 const UserActionLog: React.FC = () => {
   const [fromDate, setFromDate] = useState("2025-05-31");
   const [toDate, setToDate] = useState("2025-06-01");
-  const dispatch = useDispatch();
-  const logs = useSelector((state: any) => state.logs);
+  const dispatch = useDispatch<AppDispatch>();
+  const logs = useSelector((state: RootState) => state.logs);
   const [loading, setLoading] = useState(false);
 
   const handleRetrieveLogs = async () => {

--- a/frontend/src/components/utils/util.ts
+++ b/frontend/src/components/utils/util.ts
@@ -1,4 +1,5 @@
 import { carriers } from "../../constants/constants";
+import { CarrierList, Dashboard, TowerStatus, Activity } from "../../types/carrierType";
 
 export const getCarrierDetails = (
   user: {
@@ -27,15 +28,16 @@ export const getUserName = (
   return userName;
 };
 
-export const formatCarrierData = (carrierList: any) => {
+
+export const formatCarrierData = (carrierList: CarrierList): Dashboard => {
   let activeTowers = 0;
   let totalDevices = 0;
   let users = 0;
   let securityAlerts = 0;
-  const towerStatuses: any = [];
-  const recentActivity: any = [];
+  const towerStatuses: TowerStatus[] = [];
+  const recentActivity: Activity[] = [];
 
-  carrierList.forEach((carrier: any) => {
+  carrierList.forEach((carrier) => {
     activeTowers += carrier.dashboard.activeTowers;
     totalDevices += carrier.dashboard.totalDevices;
     users += carrier.dashboard.users;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import "./index.css";

--- a/frontend/src/store/dashboard/dashboardActions.ts
+++ b/frontend/src/store/dashboard/dashboardActions.ts
@@ -1,3 +1,6 @@
 import { createAction } from "@reduxjs/toolkit";
+import { CarrierList } from "../../types/carrierType";
 
-export const setDashboardData = createAction("dashboard/setDashboardData");
+export const setDashboardData = createAction<CarrierList>(
+  "dashboard/setDashboardData"
+);

--- a/frontend/src/store/dashboard/dashboardReducer.ts
+++ b/frontend/src/store/dashboard/dashboardReducer.ts
@@ -1,25 +1,9 @@
-import { createReducer } from "@reduxjs/toolkit";
+import { createReducer, PayloadAction } from "@reduxjs/toolkit";
 import { formatCarrierData } from "../../components/utils/util";
 import { setDashboardData } from "./dashboardActions";
+import { Dashboard, CarrierList } from "../../types/carrierType";
 
-interface TowerStatus {
-  id: string;
-  status: "ACTIVE" | "INACTIVE";
-}
-
-interface Activity {
-  timestamp: string;
-  message: string;
-}
-
-interface DashboardState {
-  activeTowers: number;
-  totalDevices: number;
-  users: number;
-  securityAlerts: number;
-  towerStatuses: TowerStatus[];
-  recentActivity: Activity[];
-}
+type DashboardState = Dashboard;
 
 const initialState: DashboardState = {
   activeTowers: 25,
@@ -53,9 +37,8 @@ const initialState: DashboardState = {
 };
 
 const dashboardReducer = createReducer(initialState, (builder) => {
-  builder.addCase(setDashboardData, (state, action) => {
-    const { data } = action.payload;
-    return formatCarrierData(data);
+  builder.addCase(setDashboardData, (state, action: PayloadAction<CarrierList>) => {
+    return formatCarrierData(action.payload);
   });
 });
 

--- a/frontend/src/store/dashboard/dashboardThunks.ts
+++ b/frontend/src/store/dashboard/dashboardThunks.ts
@@ -1,11 +1,15 @@
 import axios from "axios";
 import { API_BASE } from "../../constants/constants";
 import { setDashboardData } from "./dashboardActions";
+import { CarrierList } from "../../types/carrierType";
+import { AppDispatch } from "../store";
 
-export const fetchDashboard = (carrier: string) => async (dispatch: any) => {
-  const response = await axios.get(`${API_BASE}/dashboard`, {
+export const fetchDashboard = (carrier: string) => async (
+  dispatch: AppDispatch
+) => {
+  const response = await axios.get<CarrierList>(`${API_BASE}/dashboard`, {
     params: { carrier },
     headers: { "Cache-Control": "no-cache" },
   });
-  dispatch(setDashboardData(response));
+  dispatch(setDashboardData(response.data));
 };

--- a/frontend/src/store/device/deviceActions.ts
+++ b/frontend/src/store/device/deviceActions.ts
@@ -1,4 +1,9 @@
 import { createAction } from "@reduxjs/toolkit";
+import { Device } from "../../types/carrierType";
 
-export const setDiscoveredDevices = createAction<any[]>("device/setDiscoveredDevices");
-export const setSimulatedDevice = createAction<any>("device/setSimulatedDevice");
+export const setDiscoveredDevices = createAction<Device[]>(
+  "device/setDiscoveredDevices"
+);
+export const setSimulatedDevice = createAction<Device>(
+  "device/setSimulatedDevice"
+);

--- a/frontend/src/store/device/deviceReducer.ts
+++ b/frontend/src/store/device/deviceReducer.ts
@@ -1,10 +1,6 @@
 import { createReducer } from "@reduxjs/toolkit";
 import { setDiscoveredDevices, setSimulatedDevice } from "./deviceActions";
-
-interface DeviceState {
-  discovered: any[];
-  simulated: any | null;
-}
+import { DeviceState } from "../../types/carrierType";
 
 const initialState: DeviceState = {
   discovered: [],

--- a/frontend/src/store/device/deviceThunks.ts
+++ b/frontend/src/store/device/deviceThunks.ts
@@ -1,13 +1,17 @@
 import axios from "axios";
 import { API_BASE } from "../../constants/constants";
 import { setDiscoveredDevices, setSimulatedDevice } from "./deviceActions";
+import { Device } from "../../types/carrierType";
+import { AppDispatch } from "../store";
 
-export const fetchDevices = () => async (dispatch: any) => {
-  const res = await axios.get(`${API_BASE}/device-discovery`);
+export const fetchDevices = () => async (dispatch: AppDispatch) => {
+  const res = await axios.get<Device[]>(`${API_BASE}/device-discovery`);
   dispatch(setDiscoveredDevices(res.data));
 };
 
-export const simulateDevice = (device: any) => async (dispatch: any) => {
+export const simulateDevice = (device: Device) => async (
+  dispatch: AppDispatch
+) => {
   await axios.post(`${API_BASE}/simulate-device`, device);
   dispatch(setSimulatedDevice(device));
 };

--- a/frontend/src/store/policy/policyThunks.ts
+++ b/frontend/src/store/policy/policyThunks.ts
@@ -1,8 +1,12 @@
 import axios from "axios";
 import { API_BASE } from "../../constants/constants";
 import { setPolicyApplied } from "./policyActions";
+import { AppDispatch } from "../store";
+import { PolicyPayload } from "../../types/carrierType";
 
-export const savePolicy = (payload: any) => async (dispatch: any) => {
+export const savePolicy = (payload: PolicyPayload) => async (
+  dispatch: AppDispatch
+) => {
   await axios.post(`${API_BASE}/policy`, payload);
   dispatch(setPolicyApplied(true));
 };

--- a/frontend/src/store/towers/towerThunks.ts
+++ b/frontend/src/store/towers/towerThunks.ts
@@ -1,14 +1,19 @@
 import axios from "axios";
 import { API_BASE } from "../../constants/constants";
 import { setTowers, removeTowerId } from "./towerActions";
+import { AppDispatch } from "../store";
+import { Tower } from "../../types/carrierType";
+import { TowerRegistrationData } from "../../types/carrierType";
 
-export const fetchTowers = () => async (dispatch: any) => {
-  const response = await axios.get(`${API_BASE}/towers`);
-  const ids = response.data.map((t: any) => t.towerId);
+export const fetchTowers = () => async (dispatch: AppDispatch) => {
+  const response = await axios.get<Tower[]>(`${API_BASE}/towers`);
+  const ids = response.data.map((t) => t.id);
   dispatch(setTowers(ids));
 };
 
-export const registerTower = (data: any) => async (dispatch: any) => {
+export const registerTower = (data: TowerRegistrationData) => async (
+  dispatch: AppDispatch
+) => {
   await axios.post(`${API_BASE}/register-tower`, data);
   dispatch(removeTowerId(data.id));
 };

--- a/frontend/src/store/user/userActions.ts
+++ b/frontend/src/store/user/userActions.ts
@@ -1,6 +1,5 @@
 import { createAction } from "@reduxjs/toolkit";
+import { User } from "../../types/carrierType";
 
-export const setUser = createAction<{ username: string; password: string }>(
-  "user/setUser"
-);
+export const setUser = createAction<User>("user/setUser");
 export const clearUser = createAction("user/clearUser");

--- a/frontend/src/store/user/userReducer.ts
+++ b/frontend/src/store/user/userReducer.ts
@@ -1,11 +1,8 @@
-import { createReducer } from "@reduxjs/toolkit";
+import { createReducer, PayloadAction } from "@reduxjs/toolkit";
 import { setUser, clearUser } from "./userActions";
+import { User } from "../../types/carrierType";
 
-interface UserState {
-  username: string;
-  password: string;
-  carrier: string;
-}
+type UserState = User;
 
 const initialState: UserState = {
   username: "",
@@ -15,7 +12,7 @@ const initialState: UserState = {
 
 const userReducer = createReducer(initialState, (builder) => {
   builder
-    .addCase(setUser, (state, action: any) => {
+    .addCase(setUser, (state, action: PayloadAction<User>) => {
       state.username = action.payload.username;
       state.password = action.payload.password;
       state.carrier = action.payload.carrier;

--- a/frontend/src/store/userlogs/logActions.ts
+++ b/frontend/src/store/userlogs/logActions.ts
@@ -1,3 +1,4 @@
 import { createAction } from "@reduxjs/toolkit";
+import { LogEntry } from "../../types/carrierType";
 
-export const setUserLogs = createAction<any[]>("logs/setUserLogs");
+export const setUserLogs = createAction<LogEntry[]>("logs/setUserLogs");

--- a/frontend/src/store/userlogs/logReducer.ts
+++ b/frontend/src/store/userlogs/logReducer.ts
@@ -1,7 +1,8 @@
 import { createReducer } from "@reduxjs/toolkit";
 import { setUserLogs } from "./logActions";
+import { LogEntry } from "../../types/carrierType";
 
-const logReducer = createReducer<any[]>([], (builder) => {
+const logReducer = createReducer<LogEntry[]>([], (builder) => {
   builder.addCase(setUserLogs, (_, action) => action.payload);
 });
 

--- a/frontend/src/store/userlogs/logThunks.ts
+++ b/frontend/src/store/userlogs/logThunks.ts
@@ -1,10 +1,12 @@
 import axios from "axios";
 import { API_BASE } from "../../constants/constants";
 import { setUserLogs } from "./logActions";
+import { LogEntry } from "../../types/carrierType";
+import { AppDispatch } from "../store";
 
 export const fetchUserLogs =
   (params: { carrier: string; start: string; end: string }) =>
-  async (dispatch: any) => {
-    const response = await axios.get(`${API_BASE}/user-logs`, { params });
+  async (dispatch: AppDispatch) => {
+    const response = await axios.get<LogEntry[]>(`${API_BASE}/user-logs`, { params });
     dispatch(setUserLogs(response.data));
   };

--- a/frontend/src/types/carrierType.ts
+++ b/frontend/src/types/carrierType.ts
@@ -1,78 +1,113 @@
-export type Tower = {
+export interface Tower {
   id: string;
   status: "ACTIVE" | "INACTIVE";
-};
+}
 
-export type DashboardStats = {
+export interface DashboardStats {
   activeTowers: number;
   totalDevices: number;
   users: number;
   securityAlerts: number;
-};
+}
 
-export type RecentActivity = {
+export interface RecentActivity {
   timestamp: string; // ISO datetime format
   message: string;
-};
+}
 
-export type Carrier = {
+export interface Carrier {
   carrierName: string;
   email: string;
   towers: Tower[];
   dashboard: DashboardStats;
   recentActivity: RecentActivity[];
-};
+}
 
 export type CarrierList = Carrier[];
 
-type User = {
+export interface User {
   username: string;
   password: string;
   carrier: string;
-};
+}
 
-type Location = {
+export interface Location {
   latitude: number;
   longitude: number;
-};
+}
 
-type TowerStatus = {
+export interface TowerStatus {
   id: string;
-  status: string;
+  status: "ACTIVE" | "INACTIVE";
   towerType: string;
   location: Location;
   installDate: string;
   coverageRadius: number;
-};
+}
 
-type Activity = {
+export interface Activity {
   timestamp: string;
   message: string;
   by: User;
-};
+}
 
-type Device = {
-  discovered: any[]; // You can replace `any` with a proper type if known
-  simulated: any | null; // Replace `any` with actual simulated device type if defined
-};
+export interface LogEntry {
+  userId: string;
+  action: string;
+  timestamp: string;
+}
 
-type Policy = {
+export interface Device {
+  ip: string;
+  mac: string;
+  vendor: string;
+  model: string;
+  carrier?: string;
+  status?: string;
+  user?: User;
+}
+
+export interface DeviceState {
+  discovered: Device[];
+  simulated: Device | null;
+}
+
+export interface PolicyState {
   applied: boolean;
-  logs: any[]; // Replace with specific log type if available
-};
+  logs: LogEntry[];
+}
 
-type Dashboard = {
+export interface PolicyPayload {
+  policyName: string;
+  policyType: string;
+  apply: Record<string, boolean>;
+  user: string;
+  carrier: string;
+}
+
+export interface TowerRegistrationData {
+  id: string;
+  location: string;
+  towerType: string;
+  installationDate: string;
+  coverageRadius: string;
+  carriers: string[];
+  supportedOS: string[];
+  user: User;
+}
+
+export interface Dashboard {
   activeTowers: number;
   totalDevices: number;
   users: number;
   securityAlerts: number;
   towerStatuses: TowerStatus[];
   recentActivity: Activity[];
-};
+}
 
-export type AppState = {
+export interface AppState {
   user: User;
   dashboard: Dashboard;
-  towers: any[];
-  policy: Policy;
-};
+  towers: string[];
+  policy: PolicyState;
+}


### PR DESCRIPTION
## Summary
- centralize shared interfaces in `types/carrierType.ts`
- update Redux actions, reducers and thunks to use the shared types
- update components to import types and remove `any`
- remove unused `StrictMode`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
