### PR TITLE
Add dotenv config support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration
+# Copy this file to .env and adjust values as needed
+
+PORT=8000
+DB_HOST=localhost
+DB_USER=user
+DB_PASS=pass
+DB_NAME=telecom

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Progressive Web App (PWA) so users can access data even without a network connec
    cd backend && npm install
    cd ../frontend && npm install
    ```
-2. Start the development environment (runs server and client concurrently):
+2. Copy `.env.example` to `.env` and update any values if required.
+3. Start the development environment (runs server and client concurrently):
    ```bash
    npm start
    ```
    The API server will run on `http://localhost:8000` and the client on `http://localhost:5173`.
-3. For a production build with offline capability:
+4. For a production build with offline capability:
    ```bash
    cd frontend && npm run build
    ```

--- a/backend/app.js
+++ b/backend/app.js
@@ -2,8 +2,17 @@ const express = require("express");
 const fs = require("fs");
 const cors = require("cors");
 const bodyParser = require("body-parser");
+require("dotenv").config();
+
 const app = express();
-const PORT = 8000;
+
+const {
+  PORT = 8000,
+  DB_HOST,
+  DB_USER,
+  DB_PASS,
+  DB_NAME,
+} = process.env;
 
 app.use(cors({ origin: "*" }));
 app.use(bodyParser.json());
@@ -251,6 +260,11 @@ app.get("/api/user-logs", (req, res) => {
   }
 });
 
-app.listen(PORT, () =>
-  console.log(`Server running on http://localhost:${PORT}`)
-);
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+  if (DB_HOST) {
+    console.log(
+      `Database: ${DB_NAME || ""} at ${DB_HOST} as ${DB_USER || ""}`
+    );
+  }
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"


### PR DESCRIPTION
## Summary
- add dotenv dependency
- load .env in backend
- log database info on startup
- provide example environment file
- document using the .env file before running `npm start`
